### PR TITLE
Add missing command methods to provide complete interface to all firmware commands

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,3 @@
 teensytoany/_version.py export-subst
+# SCM syntax highlighting & preventing 3-way merges
+pixi.lock merge=binary linguist-language=YAML linguist-generated=true

--- a/.gitignore
+++ b/.gitignore
@@ -100,3 +100,8 @@ ENV/
 
 # mypy
 .mypy_cache/
+# pixi environments
+.pixi/*
+!.pixi/config.toml
+pixi.toml
+pixi.lock

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,6 +1,6 @@
 # History
 
-## 0.12.0 (2025-01-XX)
+## 0.12.0 (2025-08-21)
 
 * Add missing command methods to provide complete interface to all firmware commands:
   - I2C commands: `i2c_reset`, `i2c_read_no_register_uint8`, `i2c_write_no_register_uint8`,

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -5,16 +5,18 @@
 * Add missing command methods to provide complete interface to all firmware commands:
   - I2C commands: `i2c_reset`, `i2c_read_no_register_uint8`, `i2c_write_no_register_uint8`,
     `i2c_read_payload_uint16`, `i2c_begin_transaction`, `i2c_write`, `i2c_end_transaction`,
-    `i2c_buffer_size`
+    `i2c_buffer_size`, `i2c_write_bulk`
   - I2C_1 commands: `i2c_1_reset`, `i2c_1_read_no_register_uint8`, `i2c_1_write_no_register_uint8`,
     `i2c_1_read_payload_uint16`, `i2c_1_begin_transaction`, `i2c_1_write`, `i2c_1_end_transaction`,
-    `i2c_1_buffer_size`
+    `i2c_1_buffer_size`, `i2c_1_write_bulk`
   - SPI commands: `spi_buffer_size`, `spi_set_clock_divider`
   - Register commands: `register_read_uint8`, `register_write_uint8`, `register_read_uint32`,
     `register_write_uint32`
   - Startup/Demo commands: `post_serial_startup_commands_available`, `read_post_serial_startup_command`
   - Utility commands: `sleep_seconds`
   - Info commands: `info`, `reboot`, `serialnumber`, `license`
+* Add `i2c_write_bulk` and `i2c_1_write_bulk` methods for writing up to 8k bytes with automatic
+  chunking and transaction management
 
 ## 0.11.1 (2025-07-18)
 

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -14,9 +14,10 @@
     `register_write_uint32`
   - Startup/Demo commands: `post_serial_startup_commands_available`, `read_post_serial_startup_command`
   - Utility commands: `sleep_seconds`
-  - Info commands: `info`, `reboot`, `serialnumber`, `license`
+  - Info commands: `info`, `reboot`, `serialnumber`, `license`, `nop`
 * Add `i2c_write_bulk` and `i2c_1_write_bulk` methods for writing up to 8k bytes with automatic
   chunking and transaction management
+* Add `nop` command for testing purposes and comprehensive test suite
 
 ## 0.11.1 (2025-07-18)
 

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,21 @@
 # History
 
+## 0.12.0 (2025-01-XX)
+
+* Add missing command methods to provide complete interface to all firmware commands:
+  - I2C commands: `i2c_reset`, `i2c_read_no_register_uint8`, `i2c_write_no_register_uint8`,
+    `i2c_read_payload_uint16`, `i2c_begin_transaction`, `i2c_write`, `i2c_end_transaction`,
+    `i2c_buffer_size`
+  - I2C_1 commands: `i2c_1_reset`, `i2c_1_read_no_register_uint8`, `i2c_1_write_no_register_uint8`,
+    `i2c_1_read_payload_uint16`, `i2c_1_begin_transaction`, `i2c_1_write`, `i2c_1_end_transaction`,
+    `i2c_1_buffer_size`
+  - SPI commands: `spi_buffer_size`, `spi_set_clock_divider`
+  - Register commands: `register_read_uint8`, `register_write_uint8`, `register_read_uint32`,
+    `register_write_uint32`
+  - Startup/Demo commands: `post_serial_startup_commands_available`, `read_post_serial_startup_command`
+  - Utility commands: `sleep_seconds`
+  - Info commands: `info`, `reboot`, `serialnumber`, `license`
+
 ## 0.11.1 (2025-07-18)
 
 * Provide an ability to define the device name at initialization time.

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,4 @@
+[pytest]
+markers =
+    hardware: marks tests as requiring hardware (deselect with '-m "not hardware"')
+addopts = -m "not hardware"

--- a/teensytoany/teensytoany.py
+++ b/teensytoany/teensytoany.py
@@ -620,7 +620,8 @@ class TeensyToAny:
         cmd = f"i2c_write_no_register_uint8 0x{address:02x} 0x{data:02x}"
         self._ask(cmd)
 
-    def i2c_read_payload_uint16(self, address: int, register_address: int, num_bytes: int) -> Sequence:
+    def i2c_read_payload_uint16(self, address: int, register_address: int,
+                                num_bytes: int) -> Sequence:
         """Read up to 256 bytes from the I2C bus starting at a specified 16 bit register address."""
         cmd = f"i2c_read_payload_uint16 0x{address:02x} 0x{register_address:04x} {num_bytes}"
         returned = self._ask(cmd)
@@ -787,8 +788,9 @@ class TeensyToAny:
         cmd = f"i2c_1_write_no_register_uint8 0x{address:02x} 0x{data:02x}"
         self._ask(cmd)
 
-    def i2c_1_read_payload_uint16(self, address: int, register_address: int, num_bytes: int) -> Sequence:
-        """Read up to 256 bytes from the I2C_1 bus starting at a specified 16 bit register address."""
+    def i2c_1_read_payload_uint16(self, address: int, register_address: int,
+                                  num_bytes: int) -> Sequence:
+        """Read up to 256 bytes from the I2C_1 bus at a specified 16 bit register address."""
         cmd = f"i2c_1_read_payload_uint16 0x{address:02x} 0x{register_address:04x} {num_bytes}"
         returned = self._ask(cmd)
         register_data = [int(val, base=0) for val in returned.split()]

--- a/teensytoany/teensytoany.py
+++ b/teensytoany/teensytoany.py
@@ -643,6 +643,32 @@ class TeensyToAny:
         cmd = f"i2c_end_transaction {str(stop).lower()}"
         self._ask(cmd)
 
+    def i2c_write_bulk(self, address: int, data: Sequence):
+        """Write large amounts of data to the I2C device in chunks.
+
+        This method automatically handles chunking data to fit within the I2C buffer
+        size and manages the transaction lifecycle.
+
+        Parameters
+        ----------
+        address: int
+            I2C device address
+        data: Sequence
+            Data to write (up to 8k bytes)
+        """
+        if len(data) > 8192:
+            raise ValueError("Data size exceeds maximum of 8192 bytes")
+
+        buffer_size = self.i2c_buffer_size()
+        self.i2c_begin_transaction(address)
+
+        try:
+            for i in range(0, len(data), buffer_size):
+                chunk = data[i:i + buffer_size]
+                self.i2c_write(chunk)
+        finally:
+            self.i2c_end_transaction()
+
     def i2c_buffer_size(self):
         """Get the maximum I2C buffer size for this board."""
         returned = self._ask("i2c_buffer_size")
@@ -783,6 +809,32 @@ class TeensyToAny:
         """End a transaction with the I2C_1 device."""
         cmd = f"i2c_1_end_transaction {str(stop).lower()}"
         self._ask(cmd)
+
+    def i2c_1_write_bulk(self, address: int, data: Sequence):
+        """Write large amounts of data to the I2C_1 device in chunks.
+        
+        This method automatically handles chunking data to fit within the I2C_1 buffer
+        size and manages the transaction lifecycle.
+        
+        Parameters
+        ----------
+        address: int
+            I2C_1 device address
+        data: Sequence
+            Data to write (up to 8k bytes)
+        """
+        if len(data) > 8192:
+            raise ValueError("Data size exceeds maximum of 8192 bytes")
+        
+        buffer_size = self.i2c_1_buffer_size()
+        self.i2c_1_begin_transaction(address)
+        
+        try:
+            for i in range(0, len(data), buffer_size):
+                chunk = data[i:i + buffer_size]
+                self.i2c_1_write(chunk)
+        finally:
+            self.i2c_1_end_transaction()
 
     def i2c_1_buffer_size(self):
         """Get the maximum I2C_1 buffer size for this board."""

--- a/teensytoany/teensytoany.py
+++ b/teensytoany/teensytoany.py
@@ -1313,3 +1313,7 @@ class TeensyToAny:
     def license(self):
         """Display the license information for the source code running on the teensy."""
         return self._ask("license")
+
+    def nop(self):
+        """No operation (does nothing)."""
+        self._ask("nop")

--- a/teensytoany/teensytoany.py
+++ b/teensytoany/teensytoany.py
@@ -812,10 +812,10 @@ class TeensyToAny:
 
     def i2c_1_write_bulk(self, address: int, data: Sequence):
         """Write large amounts of data to the I2C_1 device in chunks.
-        
+
         This method automatically handles chunking data to fit within the I2C_1 buffer
         size and manages the transaction lifecycle.
-        
+
         Parameters
         ----------
         address: int
@@ -825,10 +825,10 @@ class TeensyToAny:
         """
         if len(data) > 8192:
             raise ValueError("Data size exceeds maximum of 8192 bytes")
-        
+
         buffer_size = self.i2c_1_buffer_size()
         self.i2c_1_begin_transaction(address)
-        
+
         try:
             for i in range(0, len(data), buffer_size):
                 chunk = data[i:i + buffer_size]

--- a/teensytoany/teensytoany.py
+++ b/teensytoany/teensytoany.py
@@ -604,6 +604,50 @@ class TeensyToAny:
         cmd = f"i2c_ping 0x{address:02x}"
         self._ask(cmd)
 
+    def i2c_reset(self):
+        """Reset the I2C PORT in case of lockup."""
+        self._ask("i2c_reset")
+
+    def i2c_read_no_register_uint8(self, address: int):
+        """Read a uint8_t from the I2C bus without specifying a register address."""
+        cmd = f"i2c_read_no_register_uint8 0x{address:02x}"
+        returned = self._ask(cmd)
+        return int(returned, base=0)
+
+    def i2c_write_no_register_uint8(self, address: int, data: int):
+        """Write a uint8_t to the I2C bus without specifying a register address."""
+        data = data & 0xFF
+        cmd = f"i2c_write_no_register_uint8 0x{address:02x} 0x{data:02x}"
+        self._ask(cmd)
+
+    def i2c_read_payload_uint16(self, address: int, register_address: int, num_bytes: int) -> Sequence:
+        """Read up to 256 bytes from the I2C bus starting at a specified 16 bit register address."""
+        cmd = f"i2c_read_payload_uint16 0x{address:02x} 0x{register_address:04x} {num_bytes}"
+        returned = self._ask(cmd)
+        register_data = [int(val, base=0) for val in returned.split()]
+        return register_data
+
+    def i2c_begin_transaction(self, address: int):
+        """Begin a transaction with the I2C device."""
+        cmd = f"i2c_begin_transaction 0x{address:02x}"
+        self._ask(cmd)
+
+    def i2c_write(self, data: Sequence):
+        """Write data to the I2C device."""
+        data_str = ' '.join([f"{val}" for val in data])
+        cmd = f"i2c_write {data_str}"
+        self._ask(cmd)
+
+    def i2c_end_transaction(self, stop: bool = True):
+        """End a transaction with the I2C device."""
+        cmd = f"i2c_end_transaction {str(stop).lower()}"
+        self._ask(cmd)
+
+    def i2c_buffer_size(self):
+        """Get the maximum I2C buffer size for this board."""
+        returned = self._ask("i2c_buffer_size")
+        return int(returned, base=0)
+
     def i2c_1_init(self, baud_rate: int=100_100, timeout=200_000, register_space=1):
         cmd = f"i2c_1_init {baud_rate:d} {timeout:d} {register_space:d}"
         self._ask(cmd)
@@ -700,6 +744,50 @@ class TeensyToAny:
         """Return None if device found. Raises error if no device found."""
         cmd = f"i2c_1_ping 0x{address:02x}"
         self._ask(cmd)
+
+    def i2c_1_reset(self):
+        """Reset the I2C_1 PORT in case of lockup."""
+        self._ask("i2c_1_reset")
+
+    def i2c_1_read_no_register_uint8(self, address: int):
+        """Read a uint8_t from the I2C_1 bus without specifying a register address."""
+        cmd = f"i2c_1_read_no_register_uint8 0x{address:02x}"
+        returned = self._ask(cmd)
+        return int(returned, base=0)
+
+    def i2c_1_write_no_register_uint8(self, address: int, data: int):
+        """Write a uint8_t to the I2C_1 bus without specifying a register address."""
+        data = data & 0xFF
+        cmd = f"i2c_1_write_no_register_uint8 0x{address:02x} 0x{data:02x}"
+        self._ask(cmd)
+
+    def i2c_1_read_payload_uint16(self, address: int, register_address: int, num_bytes: int) -> Sequence:
+        """Read up to 256 bytes from the I2C_1 bus starting at a specified 16 bit register address."""
+        cmd = f"i2c_1_read_payload_uint16 0x{address:02x} 0x{register_address:04x} {num_bytes}"
+        returned = self._ask(cmd)
+        register_data = [int(val, base=0) for val in returned.split()]
+        return register_data
+
+    def i2c_1_begin_transaction(self, address: int):
+        """Begin a transaction with the I2C_1 device."""
+        cmd = f"i2c_1_begin_transaction 0x{address:02x}"
+        self._ask(cmd)
+
+    def i2c_1_write(self, data: Sequence):
+        """Write data to the I2C_1 device."""
+        data_str = ' '.join([f"{val}" for val in data])
+        cmd = f"i2c_1_write {data_str}"
+        self._ask(cmd)
+
+    def i2c_1_end_transaction(self, stop: bool = True):
+        """End a transaction with the I2C_1 device."""
+        cmd = f"i2c_1_end_transaction {str(stop).lower()}"
+        self._ask(cmd)
+
+    def i2c_1_buffer_size(self):
+        """Get the maximum I2C_1 buffer size for this board."""
+        returned = self._ask("i2c_1_buffer_size")
+        return int(returned, base=0)
 
     def gpio_digital_write(self, pin, value):
         """Call the ardunio DigitalWrite function.
@@ -821,6 +909,64 @@ class TeensyToAny:
         returned = self._ask(f"register_read_uint16 {register_address}")
         return int(returned, base=0)
 
+    def register_read_uint8(self, register_address):
+        """Read value directly from a teensy register.
+
+        Parameters
+        ----------
+        register_address: int
+            Register address to read from.
+
+        Returns
+        -------
+        value: int
+            Read value. Will be from 0 to 255.
+
+        """
+        returned = self._ask(f"register_read_uint8 {register_address}")
+        return int(returned, base=0)
+
+    def register_write_uint8(self, register_address, value):
+        """Write value directly to teensy register.
+
+        Parameters
+        ----------
+        register_address: int
+            Register address to write to.
+        value: int
+            Value to write to address. Should be between 0 and 255.
+        """
+        self._ask(f"register_write_uint8 {register_address} {value}")
+
+    def register_read_uint32(self, register_address):
+        """Read value directly from a teensy register.
+
+        Parameters
+        ----------
+        register_address: int
+            Register address to read from.
+
+        Returns
+        -------
+        value: int
+            Read value. Will be from 0 to 4294967295.
+
+        """
+        returned = self._ask(f"register_read_uint32 {register_address}")
+        return int(returned, base=0)
+
+    def register_write_uint32(self, register_address, value):
+        """Write value directly to teensy register.
+
+        Parameters
+        ----------
+        register_address: int
+            Register address to write to.
+        value: int
+            Value to write to address. Should be between 0 and 4294967295.
+        """
+        self._ask(f"register_write_uint32 {register_address} {value}")
+
     @property
     def version(self):
         return self._version
@@ -914,6 +1060,15 @@ class TeensyToAny:
         """
         value = self._ask(f"spi_read_byte {data}")
         return int(value, base=0)
+
+    def spi_buffer_size(self):
+        """Get the maximum SPI buffer size for this board."""
+        returned = self._ask("spi_buffer_size")
+        return int(returned, base=0)
+
+    def spi_set_clock_divider(self, divider: int):
+        """Set the SPI clock divider."""
+        self._ask(f"spi_set_clock_divider {divider}")
 
     def analog_write_frequency(self, pin: int, frequency: int):
         frequency = int(frequency)
@@ -1051,6 +1206,20 @@ class TeensyToAny:
         """Disable the demo commands on startup."""
         self._ask("disable_demo_commands")
 
+    def post_serial_startup_commands_available(self):
+        """Return the number of post serial startup commands available."""
+        returned = self._ask("post_serial_startup_commands_available")
+        return int(returned, base=0)
+
+    def read_post_serial_startup_command(self, index):
+        """Read the post serial startup command at the specified index."""
+        returned = self._ask(f"read_post_serial_startup_command {index}")
+        return returned
+
+    def sleep_seconds(self, duration: float):
+        """Sleep (and block) for the desired duration in seconds."""
+        self._ask(f"sleep {duration}")
+
     def fastled_add_leds(self, led_class, has_white, pin, n_leds):
         has_white = int(bool(has_white))
         self._ask(f"fastled_add_leds {led_class} {has_white} {pin} {n_leds}")
@@ -1076,3 +1245,19 @@ class TeensyToAny:
 
     def fastled_set_hue(self, led_index, hue):
         self._ask(f"fastled_set_hue {led_index} {hue}")
+
+    def info(self):
+        """Displays information about this TeensyToAny device."""
+        return self._ask("info")
+
+    def reboot(self):
+        """Runs setup routine again, for this device."""
+        self._ask("reboot")
+
+    def serialnumber(self):
+        """Displays the serial number of the board."""
+        return self._ask("serialnumber")
+
+    def license(self):
+        """Display the license information for the source code running on the teensy."""
+        return self._ask("license")

--- a/teensytoany/tests/test_teensytoany.py
+++ b/teensytoany/tests/test_teensytoany.py
@@ -1,104 +1,32 @@
-import pytest
-from unittest.mock import Mock, patch, MagicMock
+import teensytoany
 from teensytoany import TeensyToAny
+import pytest
+
 
 
 def test_project_import():
-    """Test that the package can be imported correctly."""
-    import teensytoany
     assert teensytoany.__version__
     assert teensytoany.TeensyToAny
 
 
-class TestTeensyToAny:
-    """Test class for TeensyToAny functionality."""
+@pytest.mark.hardware
+def test_nop():
+    with TeensyToAny() as t:
+        t.nop()
 
-    def setup_method(self):
-        """Set up test fixtures."""
-        self.mock_serial = Mock()
-        self.mock_serial.read_until.return_value = b"0\n"
-        self.mock_serial.timeout = 0.205
 
-    @patch('teensytoany.teensytoany.Serial')
-    @patch('teensytoany.teensytoany.TeensyToAny.device_serial_number_pairs')
-    def test_nop_command(self, mock_device_pairs, mock_serial_class):
-        """Test that the nop command works correctly."""
-        mock_device_pairs.return_value = [('/dev/ttyACM0', '123456')]
-        mock_serial_class.return_value = self.mock_serial
-        
-        teensy = TeensyToAny(open=False)
-        teensy._serial = self.mock_serial
-        teensy._version = "0.0.1"
-        
-        teensy.nop()
-        
-        self.mock_serial.write.assert_called_with(b"nop\n")
-        self.mock_serial.read_until.assert_called_once()
+@pytest.mark.hardware
+@pytest.mark.parametrize("i", range(256, 2048 + 1, 256))
+def test_nop_buffer_size(i):
+    # We shouldn't fail with up to 2048 bytes of input
+    with TeensyToAny() as t:
+        t._ask("nop" + " " * (2048 - i - len("nop\n")))
 
-    @patch('teensytoany.teensytoany.Serial')
-    @patch('teensytoany.teensytoany.TeensyToAny.device_serial_number_pairs')
-    def test_oversized_input_handling(self, mock_device_pairs, mock_serial_class):
-        """Test that oversized input (>2k bytes) is handled correctly by the firmware."""
-        mock_device_pairs.return_value = [('/dev/ttyACM0', '123456')]
-        mock_serial_class.return_value = self.mock_serial
-        
-        teensy = TeensyToAny(open=False)
-        teensy._serial = self.mock_serial
-        teensy._version = "0.0.1"
-        
-        # Create a command that exceeds the 2k buffer limit
-        oversized_command = "nop " + "x" * 2500
-        
-        # Mock the serial response to simulate ENOMEM error (12)
-        self.mock_serial.read_until.return_value = b"12\n"
-        
-        # The firmware should return ENOMEM (12) for oversized input
-        with pytest.raises(RuntimeError, match="Responded with Error Code 12"):
-            teensy._ask(oversized_command)
-        
-        # Verify the command was written to serial
-        self.mock_serial.write.assert_called_with((oversized_command + '\n').encode('utf-8'))
 
-    @patch('teensytoany.teensytoany.Serial')
-    @patch('teensytoany.teensytoany.TeensyToAny.device_serial_number_pairs')
-    def test_normal_command_works(self, mock_device_pairs, mock_serial_class):
-        """Test that normal commands work correctly."""
-        mock_device_pairs.return_value = [('/dev/ttyACM0', '123456')]
-        mock_serial_class.return_value = self.mock_serial
-        
-        teensy = TeensyToAny(open=False)
-        teensy._serial = self.mock_serial
-        teensy._version = "0.0.1"
-        
-        # Mock successful response
-        self.mock_serial.read_until.return_value = b"0\n"
-        
-        result = teensy._ask("nop")
-        assert result is None
-        
-        self.mock_serial.write.assert_called_with(b"nop\n")
-
-    @patch('teensytoany.teensytoany.Serial')
-    @patch('teensytoany.teensytoany.TeensyToAny.device_serial_number_pairs')
-    def test_buffer_size_limits(self, mock_device_pairs, mock_serial_class):
-        """Test that commands near the buffer limit are handled correctly."""
-        mock_device_pairs.return_value = [('/dev/ttyACM0', '123456')]
-        mock_serial_class.return_value = self.mock_serial
-        
-        teensy = TeensyToAny(open=False)
-        teensy._serial = self.mock_serial
-        teensy._version = "0.0.1"
-        
-        # Test with command just under the limit (2048 bytes - some overhead)
-        large_command = "nop " + "x" * 2000
-        self.mock_serial.read_until.return_value = b"0\n"
-        
-        result = teensy._ask(large_command)
-        assert result is None
-        
-        # Test with command at the limit
-        limit_command = "nop " + "x" * 2040
-        self.mock_serial.read_until.return_value = b"0\n"
-        
-        result = teensy._ask(limit_command)
-        assert result is None
+@pytest.mark.hardware
+@pytest.mark.parametrize("i", range(2048, 8096 + 1, 2048))
+def test_nop_buffer_size_fail(i):
+    with TeensyToAny() as t:
+        # We should fail with more than 2048 bytes of input
+        with pytest.raises(Exception):
+            t._ask("nop" + " " * (i + 1 - len("nop\n")))

--- a/teensytoany/tests/test_teensytoany.py
+++ b/teensytoany/tests/test_teensytoany.py
@@ -1,8 +1,104 @@
-import teensytoany
-
-# import pytest
+import pytest
+from unittest.mock import Mock, patch, MagicMock
+from teensytoany import TeensyToAny
 
 
 def test_project_import():
+    """Test that the package can be imported correctly."""
+    import teensytoany
     assert teensytoany.__version__
     assert teensytoany.TeensyToAny
+
+
+class TestTeensyToAny:
+    """Test class for TeensyToAny functionality."""
+
+    def setup_method(self):
+        """Set up test fixtures."""
+        self.mock_serial = Mock()
+        self.mock_serial.read_until.return_value = b"0\n"
+        self.mock_serial.timeout = 0.205
+
+    @patch('teensytoany.teensytoany.Serial')
+    @patch('teensytoany.teensytoany.TeensyToAny.device_serial_number_pairs')
+    def test_nop_command(self, mock_device_pairs, mock_serial_class):
+        """Test that the nop command works correctly."""
+        mock_device_pairs.return_value = [('/dev/ttyACM0', '123456')]
+        mock_serial_class.return_value = self.mock_serial
+        
+        teensy = TeensyToAny(open=False)
+        teensy._serial = self.mock_serial
+        teensy._version = "0.0.1"
+        
+        teensy.nop()
+        
+        self.mock_serial.write.assert_called_with(b"nop\n")
+        self.mock_serial.read_until.assert_called_once()
+
+    @patch('teensytoany.teensytoany.Serial')
+    @patch('teensytoany.teensytoany.TeensyToAny.device_serial_number_pairs')
+    def test_oversized_input_handling(self, mock_device_pairs, mock_serial_class):
+        """Test that oversized input (>2k bytes) is handled correctly by the firmware."""
+        mock_device_pairs.return_value = [('/dev/ttyACM0', '123456')]
+        mock_serial_class.return_value = self.mock_serial
+        
+        teensy = TeensyToAny(open=False)
+        teensy._serial = self.mock_serial
+        teensy._version = "0.0.1"
+        
+        # Create a command that exceeds the 2k buffer limit
+        oversized_command = "nop " + "x" * 2500
+        
+        # Mock the serial response to simulate ENOMEM error (12)
+        self.mock_serial.read_until.return_value = b"12\n"
+        
+        # The firmware should return ENOMEM (12) for oversized input
+        with pytest.raises(RuntimeError, match="Responded with Error Code 12"):
+            teensy._ask(oversized_command)
+        
+        # Verify the command was written to serial
+        self.mock_serial.write.assert_called_with((oversized_command + '\n').encode('utf-8'))
+
+    @patch('teensytoany.teensytoany.Serial')
+    @patch('teensytoany.teensytoany.TeensyToAny.device_serial_number_pairs')
+    def test_normal_command_works(self, mock_device_pairs, mock_serial_class):
+        """Test that normal commands work correctly."""
+        mock_device_pairs.return_value = [('/dev/ttyACM0', '123456')]
+        mock_serial_class.return_value = self.mock_serial
+        
+        teensy = TeensyToAny(open=False)
+        teensy._serial = self.mock_serial
+        teensy._version = "0.0.1"
+        
+        # Mock successful response
+        self.mock_serial.read_until.return_value = b"0\n"
+        
+        result = teensy._ask("nop")
+        assert result is None
+        
+        self.mock_serial.write.assert_called_with(b"nop\n")
+
+    @patch('teensytoany.teensytoany.Serial')
+    @patch('teensytoany.teensytoany.TeensyToAny.device_serial_number_pairs')
+    def test_buffer_size_limits(self, mock_device_pairs, mock_serial_class):
+        """Test that commands near the buffer limit are handled correctly."""
+        mock_device_pairs.return_value = [('/dev/ttyACM0', '123456')]
+        mock_serial_class.return_value = self.mock_serial
+        
+        teensy = TeensyToAny(open=False)
+        teensy._serial = self.mock_serial
+        teensy._version = "0.0.1"
+        
+        # Test with command just under the limit (2048 bytes - some overhead)
+        large_command = "nop " + "x" * 2000
+        self.mock_serial.read_until.return_value = b"0\n"
+        
+        result = teensy._ask(large_command)
+        assert result is None
+        
+        # Test with command at the limit
+        limit_command = "nop " + "x" * 2040
+        self.mock_serial.read_until.return_value = b"0\n"
+        
+        result = teensy._ask(limit_command)
+        assert result is None

--- a/teensytoany/tests/test_teensytoany.py
+++ b/teensytoany/tests/test_teensytoany.py
@@ -1,7 +1,7 @@
-import teensytoany
-from teensytoany import TeensyToAny
 import pytest
 
+import teensytoany
+from teensytoany import TeensyToAny
 
 
 def test_project_import():
@@ -16,11 +16,12 @@ def test_nop():
 
 
 @pytest.mark.hardware
-@pytest.mark.parametrize("i", range(256, 2048 + 1, 256))
+@pytest.mark.parametrize("i", range(256, 2048, 256))
 def test_nop_buffer_size(i):
     # We shouldn't fail with up to 2048 bytes of input
     with TeensyToAny() as t:
-        t._ask("nop" + " " * (2048 - i - len("nop\n")))
+        # pylint: disable=protected-access
+        t._ask("nop" + " " * (2048 - len("nop\n") - i))
 
 
 @pytest.mark.hardware
@@ -29,4 +30,5 @@ def test_nop_buffer_size_fail(i):
     with TeensyToAny() as t:
         # We should fail with more than 2048 bytes of input
         with pytest.raises(Exception):
+            # pylint: disable=protected-access
             t._ask("nop" + " " * (i + 1 - len("nop\n")))


### PR DESCRIPTION
- I2C commands: i2c_reset, i2c_read_no_register_uint8, i2c_write_no_register_uint8, i2c_read_payload_uint16, i2c_begin_transaction, i2c_write, i2c_end_transaction, i2c_buffer_size
- I2C_1 commands: i2c_1_reset, i2c_1_read_no_register_uint8, i2c_1_write_no_register_uint8, i2c_1_read_payload_uint16, i2c_1_begin_transaction, i2c_1_write, i2c_1_end_transaction, i2c_1_buffer_size
- SPI commands: spi_buffer_size, spi_set_clock_divider
- Register commands: register_read_uint8, register_write_uint8, register_read_uint32, register_write_uint32
- Startup/Demo commands: post_serial_startup_commands_available, read_post_serial_startup_command
- Utility commands: sleep_seconds
- Info commands: info, reboot, serialnumber, license



* [ ] Add note in `HISTORY.md` of the user
* [ ] Add tests if relevant.
* [ ] Add your name to the `AUTHORS.md` file

